### PR TITLE
feature-6-delete-listing

### DIFF
--- a/src/main/java/intefaceAdapters/deleteListing/DeleteListingController.java
+++ b/src/main/java/intefaceAdapters/deleteListing/DeleteListingController.java
@@ -1,0 +1,23 @@
+package intefaceAdapters.deleteListing;
+
+import useCases.deleteListing.DeleteListingInteractor;
+import useCases.deleteListing.DeleteListingPresenter;
+import useCases.deleteListing.DeleteListingRequestModel;
+import useCases.deleteListing.DeleteListingResponseModel;
+
+public class DeleteListingController {
+    private final DeleteListingInteractor interactor;
+
+    public DeleteListingController(DeleteListingPresenter presenter) {
+        this.interactor = new DeleteListingInteractor(presenter);
+    }
+
+    public void displayUserListings(){
+        interactor.displayListings();
+    }
+
+    public void deleteUserListing(String uuid) {
+        DeleteListingRequestModel requestModel = new DeleteListingRequestModel(uuid);
+        interactor.deleteListing(requestModel);
+    }
+}

--- a/src/main/java/intefaceAdapters/deleteListing/DeleteListingRepo.java
+++ b/src/main/java/intefaceAdapters/deleteListing/DeleteListingRepo.java
@@ -51,9 +51,13 @@ public class DeleteListingRepo implements DeleteListingDsGateway {
     }
 
     @Override
-    public void deleteListing(String uuid){
+    public String deleteListing(String uuid){
+        DeleteListingDsRequestModel listing = listings.get(uuid);
+        String brand = listing.getBrand();
+        String name = listing.getName();
         listings.remove(uuid);
         this.save();
+        return String.format("%s %s", brand, name);
     }
 
     private void save(){

--- a/src/main/java/intefaceAdapters/deleteListing/DeleteListingRepo.java
+++ b/src/main/java/intefaceAdapters/deleteListing/DeleteListingRepo.java
@@ -1,0 +1,83 @@
+package intefaceAdapters.deleteListing;
+
+import useCases.deleteListing.DeleteListingDsGateway;
+import useCases.deleteListing.DeleteListingDsRequestModel;
+
+import java.io.*;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class DeleteListingRepo implements DeleteListingDsGateway {
+    private final Map<String, DeleteListingDsRequestModel> listings = new HashMap<>();
+    private final File csvFile;
+    private final Map<String, Integer> headers;
+
+    public DeleteListingRepo(String csvPath) throws IOException {
+        csvFile = new File(csvPath);
+        String[] headerList = {"uniqueId", "brand", "name", "color", "year", "numSeats", "price", "userEmail",
+                "phoneNumber", "description", "type", "creationTime"};
+        headers = new LinkedHashMap<>();
+        for (int i = 0; i < headerList.length; i++) {
+            headers.put(headerList[i], i);
+        }
+        if (csvFile.length() > 0) {
+            BufferedReader reader = new BufferedReader(new FileReader(csvFile));
+            reader.readLine(); // skip header
+
+            String row;
+            while ((row = reader.readLine()) != null) {
+                String[] col = row.split(",");
+                String email = String.valueOf(col[headers.get("userEmail")]);
+                String uuid = String.valueOf(col[headers.get("uniqueId")]);
+                String brand = String.valueOf(col[headers.get("brand")]);
+                String name = String.valueOf(col[headers.get("name")]);
+                String color = String.valueOf(col[headers.get("color")]);
+                String year = String.valueOf(col[headers.get("year")]);
+                String numSeats = String.valueOf(col[headers.get("numSeats")]);
+                String price = String.valueOf(col[headers.get("price")]);
+                String phoneNumber = String.valueOf(col[headers.get("phoneNumber")]);
+                String description = String.valueOf(col[headers.get("description")]);
+                String type = String.valueOf(col[headers.get("type")]);
+                String creationTimeText = String.valueOf(col[headers.get("creationTime")]);
+                LocalDateTime ldt = LocalDateTime.parse(creationTimeText);
+                DeleteListingDsRequestModel listing = new DeleteListingDsRequestModel(uuid, email, brand, name, color, year, numSeats, price, phoneNumber, description, type, ldt);
+                listings.put(uuid, listing);
+            }
+
+            reader.close();
+        }
+    }
+
+    @Override
+    public void deleteListing(String uuid){
+        listings.remove(uuid);
+        this.save();
+    }
+
+    private void save(){
+        BufferedWriter writer;
+        try {
+            writer = new BufferedWriter(new FileWriter(csvFile));
+            writer.write(String.join(",", headers.keySet()));
+            writer.newLine();
+
+            for (DeleteListingDsRequestModel listing : listings.values()) {
+                String line = String.format("%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s", listing.getUuid(), listing.getBrand(), listing.getName(), listing.getColor(), listing.getYear(), listing.getNumSeats(), listing.getPrice(), listing.getUserEmail(), listing.getPhoneNumber(), listing.getDescription(), listing.getType(), listing.getLdt());
+                writer.write(line);
+                writer.newLine();
+            }
+
+            writer.close();
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Map<String, DeleteListingDsRequestModel> getListings() {
+        return listings;
+    }
+}

--- a/src/main/java/intefaceAdapters/deleteListing/DeleteListingResponseFormatter.java
+++ b/src/main/java/intefaceAdapters/deleteListing/DeleteListingResponseFormatter.java
@@ -1,0 +1,31 @@
+package intefaceAdapters.deleteListing;
+
+import useCases.deleteListing.DeleteListingDsRequestModel;
+import useCases.deleteListing.DeleteListingPresenter;
+import useCases.deleteListing.DeleteListingResponseModel;
+
+import java.util.List;
+
+public class DeleteListingResponseFormatter implements DeleteListingPresenter {
+    private final DeleteListingScreenInterface view;
+
+    public DeleteListingResponseFormatter(DeleteListingScreenInterface view) {
+        this.view = view;
+    }
+
+    @Override
+    public void displayUserListings(DeleteListingResponseModel responseModel) {
+        List<DeleteListingDsRequestModel> listings = responseModel.getRequestModel();
+        view.displayUserListings(listings);
+    }
+
+    @Override
+    public void sendFailureMessage(String message) {
+        view.showFailerMessage(message);
+    }
+
+    @Override
+    public void deletedListingMessage(String message) {
+        view.showDeletedMessage(message);
+    }
+}

--- a/src/main/java/intefaceAdapters/deleteListing/DeleteListingResponseFormatter.java
+++ b/src/main/java/intefaceAdapters/deleteListing/DeleteListingResponseFormatter.java
@@ -20,11 +20,6 @@ public class DeleteListingResponseFormatter implements DeleteListingPresenter {
     }
 
     @Override
-    public void sendFailureMessage(String message) {
-        view.showFailerMessage(message);
-    }
-
-    @Override
     public void deletedListingMessage(String message) {
         view.showDeletedMessage(message);
     }

--- a/src/main/java/intefaceAdapters/deleteListing/DeleteListingScreenInterface.java
+++ b/src/main/java/intefaceAdapters/deleteListing/DeleteListingScreenInterface.java
@@ -1,0 +1,11 @@
+package intefaceAdapters.deleteListing;
+
+import useCases.deleteListing.DeleteListingDsRequestModel;
+
+import java.util.List;
+
+public interface DeleteListingScreenInterface {
+    void displayUserListings(List<DeleteListingDsRequestModel> listings);
+    void showDeletedMessage(String message);
+    void showFailerMessage(String message);
+}

--- a/src/main/java/screens/DeleteListingBox.java
+++ b/src/main/java/screens/DeleteListingBox.java
@@ -1,0 +1,41 @@
+package screens;
+
+import intefaceAdapters.deleteListing.DeleteListingController;
+import useCases.deleteListing.DeleteListingDsRequestModel;
+import useCases.deleteListing.DeleteListingRequestModel;
+
+import javax.swing.*;
+import javax.swing.border.Border;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+public class DeleteListingBox extends JPanel implements ActionListener {
+    private final DeleteListingController controller;
+    private final DeleteListingDsRequestModel listing;
+    public DeleteListingBox(DeleteListingDsRequestModel ds, DeleteListingController controller) {
+        this.controller = controller;
+        this.listing = ds;
+        Border blackline = BorderFactory.createLineBorder(Color.black);
+        String carNameYear = String.format("<h2>%s %s - %s</h2>", listing.getBrand(), listing.getName(), listing.getYear());
+        String color = String.format("<p><b>Color:</b> %s</p>", listing.getColor());
+        String numSeats = String.format("<p><b>Number of Seats:</b> %s</p>", listing.getNumSeats());
+        String price = String.format("<p><b>Price:</b> $%s</p>", listing.getPrice());
+        String description = String.format("<p><b>Description:</b> %s</p>", listing.getDescription());
+        String type = String.format("<p><b>Type:</b> %s</p>", listing.getType());
+        String content = String.format("<html>%s%s%s%s%s%s</html>",
+                carNameYear, color, numSeats, price, type, description);
+        JLabel show = new JLabel(content);
+        JButton delete = new JButton("Delete Listing");
+        delete.addActionListener(this);
+        this.add(show);
+        this.add(delete);
+        this.setBorder(blackline);
+        this.setAlignmentX(Component.LEFT_ALIGNMENT);
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        controller.deleteUserListing(listing.getUuid());
+    }
+}

--- a/src/main/java/screens/DeleteListingsScreen.java
+++ b/src/main/java/screens/DeleteListingsScreen.java
@@ -1,0 +1,85 @@
+package screens;
+
+import intefaceAdapters.deleteListing.DeleteListingController;
+import intefaceAdapters.deleteListing.DeleteListingResponseFormatter;
+import intefaceAdapters.deleteListing.DeleteListingScreenInterface;
+import useCases.deleteListing.DeleteListingDsRequestModel;
+import useCases.deleteListing.DeleteListingPresenter;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.List;
+
+public class DeleteListingsScreen extends JPanel implements DeleteListingScreenInterface, ActionListener {
+    private final DeleteListingController controller;
+    private final JPanel contentPanel;
+    private final JButton exit;
+    private final ListingCRUDScreen parent;
+
+
+    public DeleteListingsScreen(ListingCRUDScreen parent) {
+        this.parent = parent;
+        JLabel title = new JLabel("My Listings");
+        title.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+        setBounds(100, 100, 450, 300);
+
+        JScrollPane scrollPane = new JScrollPane();
+        this.add(scrollPane, BorderLayout.CENTER);
+
+        contentPanel = new JPanel();
+
+        DeleteListingPresenter presenter = new DeleteListingResponseFormatter(this);
+        this.controller = new DeleteListingController(presenter);
+        controller.displayUserListings();
+        exit = new JButton("Go Back");
+        this.add(exit);
+    }
+
+    @Override
+    public void displayUserListings(List<DeleteListingDsRequestModel> listings) {
+        if (listings.isEmpty()) {
+            JLabel msg = new JLabel("<html><h1>You have no listings</h1></html>");
+            this.add(msg);
+        } else {
+            for (DeleteListingDsRequestModel listing :
+                    listings) {
+                DeleteListingBox box = new DeleteListingBox(listing, controller);
+                contentPanel.add(box);
+            }
+            JScrollPane scrollPane = new JScrollPane();
+            this.add(scrollPane, BorderLayout.CENTER);
+            contentPanel.setLayout(new BoxLayout(contentPanel, BoxLayout.Y_AXIS));
+            contentPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+            scrollPane.setViewportView(contentPanel);
+        }
+
+
+    }
+
+    @Override
+    public void showDeletedMessage(String message) {
+        DeletedPopUp deletedPopUp = new DeletedPopUp(message);
+        deletedPopUp.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
+        deletedPopUp.setVisible(true);
+        deletedPopUp.getContButton().addActionListener(this);
+    }
+
+    @Override
+    public void showFailerMessage(String message) {
+        DeletedPopUp back = new DeletedPopUp(message);
+        back.setVisible(true);
+        back.getContButton().addActionListener(this);
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        parent.comeBackScreen();
+    }
+
+    public JButton getBackButton() {
+        return exit;
+    }
+}

--- a/src/main/java/screens/DeletedPopUp.java
+++ b/src/main/java/screens/DeletedPopUp.java
@@ -1,0 +1,32 @@
+package screens;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+public class DeletedPopUp extends JDialog implements ActionListener {
+    private final JButton contButton;
+
+    public DeletedPopUp(String message) {
+        setBounds(100, 100, 200, 100);
+        System.out.println("you are here");
+        JLabel label = new JLabel(message);
+        contButton = new JButton("Continue to Home");
+        contButton.addActionListener(this);
+        JPanel panel = new JPanel();
+        panel.add(label);
+        panel.add(contButton);
+        panel.setVisible(true);
+        this.add(panel);
+    }
+
+    public JButton getContButton() {
+        return contButton;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        this.setVisible(false);
+    }
+}

--- a/src/main/java/screens/ListingCRUDScreen.java
+++ b/src/main/java/screens/ListingCRUDScreen.java
@@ -24,6 +24,7 @@ public class ListingCRUDScreen extends JFrame implements ActionListener {
 
         createListing.addActionListener(this);
         browseListings.addActionListener(this);
+        removeListings.addActionListener(this);
 
         main = new JPanel();
         main.setLayout(new BoxLayout(main, BoxLayout.Y_AXIS));
@@ -47,6 +48,9 @@ public class ListingCRUDScreen extends JFrame implements ActionListener {
             this.setContentPane(main);
             this.pack();
         };
+        if (e.getActionCommand().equals("Remove Listings")){
+            setDeleteListingScreen();
+        }
         if (e.getActionCommand().equals("Exit")) {
             this.setContentPane(main);
             this.pack();
@@ -64,6 +68,18 @@ public class ListingCRUDScreen extends JFrame implements ActionListener {
         DisplayListingScreen displayListingScreen = new DisplayListingScreen();
         this.setContentPane(displayListingScreen);
         displayListingScreen.exitDisplayButton().addActionListener(this);
+        this.pack();
+    }
+
+    private void setDeleteListingScreen() {
+        DeleteListingsScreen deleteListingScreen = new DeleteListingsScreen(this);
+        this.setContentPane(deleteListingScreen);
+        deleteListingScreen.getBackButton().addActionListener(this);
+        this.pack();
+    }
+
+    public void comeBackScreen() {
+        this.setContentPane(main);
         this.pack();
     }
 }

--- a/src/main/java/useCases/deleteListing/DeleteListingDsGateway.java
+++ b/src/main/java/useCases/deleteListing/DeleteListingDsGateway.java
@@ -6,6 +6,6 @@ import java.util.List;
 import java.util.Map;
 
 public interface DeleteListingDsGateway {
-    void deleteListing(String uuid);
+    String deleteListing(String uuid);
     Map<String, DeleteListingDsRequestModel> getListings();
 }

--- a/src/main/java/useCases/deleteListing/DeleteListingDsGateway.java
+++ b/src/main/java/useCases/deleteListing/DeleteListingDsGateway.java
@@ -1,0 +1,11 @@
+package useCases.deleteListing;
+
+import useCases.displayListing.DisplayListingDsRequestModel;
+
+import java.util.List;
+import java.util.Map;
+
+public interface DeleteListingDsGateway {
+    void deleteListing(String uuid);
+    Map<String, DeleteListingDsRequestModel> getListings();
+}

--- a/src/main/java/useCases/deleteListing/DeleteListingDsRequestModel.java
+++ b/src/main/java/useCases/deleteListing/DeleteListingDsRequestModel.java
@@ -1,0 +1,81 @@
+package useCases.deleteListing;
+
+import java.time.LocalDateTime;
+
+public class DeleteListingDsRequestModel {
+    public String getBrand() {
+        return brand;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public String getYear() {
+        return year;
+    }
+
+    public String getNumSeats() {
+        return numSeats;
+    }
+
+    public String getPrice() {
+        return price;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public String getUserEmail() {
+        return userEmail;
+    }
+
+    private final String uuid;
+    private final String userEmail;
+    private final String brand;
+    private final String name;
+    private final String color;
+    private final String year;
+    private final String numSeats;
+    private final String price;
+    private final String phoneNumber;
+    private final String description;
+    private final String type;
+    private final LocalDateTime ldt;
+
+    public LocalDateTime getLdt() {
+        return ldt;
+    }
+
+    public DeleteListingDsRequestModel(String uuid, String userEmail, String brand, String name, String color, String year, String numSeats, String price, String phoneNumber, String description, String type, LocalDateTime ldt) {
+        this.uuid = uuid;
+        this.userEmail = userEmail;
+        this.brand = brand;
+        this.name = name;
+        this.color = color;
+        this.year = year;
+        this.numSeats = numSeats;
+        this.price = price;
+        this.phoneNumber = phoneNumber;
+        this.description = description;
+        this.type = type;
+        this.ldt = ldt;
+    }
+}

--- a/src/main/java/useCases/deleteListing/DeleteListingInputBoundary.java
+++ b/src/main/java/useCases/deleteListing/DeleteListingInputBoundary.java
@@ -1,0 +1,8 @@
+package useCases.deleteListing;
+
+import useCases.displayListing.DisplayListingRequestModel;
+
+public interface DeleteListingInputBoundary {
+    void displayListings();
+    void deleteListing(DeleteListingRequestModel deleteListingRequestModel);
+}

--- a/src/main/java/useCases/deleteListing/DeleteListingInteractor.java
+++ b/src/main/java/useCases/deleteListing/DeleteListingInteractor.java
@@ -1,0 +1,41 @@
+package useCases.deleteListing;
+
+import entities.LoggedInUserSingleton;
+import intefaceAdapters.deleteListing.DeleteListingRepo;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DeleteListingInteractor implements DeleteListingInputBoundary{
+    private DeleteListingDsGateway gateway;
+    private final DeleteListingPresenter presenter;
+
+    public DeleteListingInteractor(DeleteListingPresenter presenter) {
+        this.presenter = presenter;
+        try {
+            gateway = new DeleteListingRepo("./listings.csv");
+        } catch (IOException e) {
+            throw new RuntimeException("Could not find file");
+        }
+    }
+
+    @Override
+    public void displayListings() {
+        List<DeleteListingDsRequestModel> userListings = new ArrayList<>();
+        for (DeleteListingDsRequestModel listing :
+                gateway.getListings().values()) {
+            if(listing.getUserEmail().equals(LoggedInUserSingleton.getInstance().getEmail())){
+                userListings.add(listing);
+            }
+        }
+        DeleteListingResponseModel responseModel = new DeleteListingResponseModel("Listings found", userListings);
+        presenter.displayUserListings(responseModel);
+    }
+
+    @Override
+    public void deleteListing(DeleteListingRequestModel deleteListingRequestModel) {
+        gateway.deleteListing(deleteListingRequestModel.getUuid());
+        presenter.deletedListingMessage("Successfully deleted listing!");
+    }
+}

--- a/src/main/java/useCases/deleteListing/DeleteListingInteractor.java
+++ b/src/main/java/useCases/deleteListing/DeleteListingInteractor.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class DeleteListingInteractor implements DeleteListingInputBoundary{
-    private DeleteListingDsGateway gateway;
+    private final DeleteListingDsGateway gateway;
     private final DeleteListingPresenter presenter;
 
     public DeleteListingInteractor(DeleteListingPresenter presenter) {
@@ -35,7 +35,7 @@ public class DeleteListingInteractor implements DeleteListingInputBoundary{
 
     @Override
     public void deleteListing(DeleteListingRequestModel deleteListingRequestModel) {
-        gateway.deleteListing(deleteListingRequestModel.getUuid());
-        presenter.deletedListingMessage("Successfully deleted listing!");
+        String output = gateway.deleteListing(deleteListingRequestModel.getUuid());
+        presenter.deletedListingMessage(String.format("Successfully deleted %s listing!", output));
     }
 }

--- a/src/main/java/useCases/deleteListing/DeleteListingPresenter.java
+++ b/src/main/java/useCases/deleteListing/DeleteListingPresenter.java
@@ -1,0 +1,7 @@
+package useCases.deleteListing;
+
+public interface DeleteListingPresenter {
+    void displayUserListings(DeleteListingResponseModel responseModel);
+    void sendFailureMessage(String message);
+    void deletedListingMessage(String message);
+}

--- a/src/main/java/useCases/deleteListing/DeleteListingPresenter.java
+++ b/src/main/java/useCases/deleteListing/DeleteListingPresenter.java
@@ -2,6 +2,5 @@ package useCases.deleteListing;
 
 public interface DeleteListingPresenter {
     void displayUserListings(DeleteListingResponseModel responseModel);
-    void sendFailureMessage(String message);
     void deletedListingMessage(String message);
 }

--- a/src/main/java/useCases/deleteListing/DeleteListingRequestModel.java
+++ b/src/main/java/useCases/deleteListing/DeleteListingRequestModel.java
@@ -1,0 +1,13 @@
+package useCases.deleteListing;
+
+public class DeleteListingRequestModel {
+    private final String uuid;
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public DeleteListingRequestModel(String uuid) {
+        this.uuid = uuid;
+    }
+}

--- a/src/main/java/useCases/deleteListing/DeleteListingResponseModel.java
+++ b/src/main/java/useCases/deleteListing/DeleteListingResponseModel.java
@@ -1,0 +1,22 @@
+package useCases.deleteListing;
+
+import java.util.List;
+
+public class DeleteListingResponseModel {
+    private final String message;
+    private final List<DeleteListingDsRequestModel> requestModel;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public List<DeleteListingDsRequestModel> getRequestModel() {
+        return requestModel;
+    }
+
+    public DeleteListingResponseModel(String message, List<DeleteListingDsRequestModel> requestModel) {
+        this.message = message;
+        this.requestModel = requestModel;
+    }
+
+}


### PR DESCRIPTION
Fully implemented the delete listing use case using clean architecture.
- Logged-in users can click on Remove Listings in the CRUD screen: When they do this, listings from the database that are stored with the user's email are filtered for and sent to the view.
- The users then see listings that they posted.
- There is a delete button attached to each listing, which when clicked by the user, removes the listing from the database.