### PR TITLE
fixed program stopping when no api key present

### DIFF
--- a/src/main/java/interface_adapters/nearest_dealership/NearestDealershipApi.java
+++ b/src/main/java/interface_adapters/nearest_dealership/NearestDealershipApi.java
@@ -31,6 +31,9 @@ public class NearestDealershipApi implements NearestDealershipApiGateway {
      */
     @Override
     public NearestDealershipResponseModel getClosestDealership(List<DealershipDsRequestModel> dealerships, String userLocation){
+        if (API_KEY.equals("")) {
+            return new NearestDealershipResponseModel("none", "none", "none", "none");
+        }
         DealershipDsRequestModel closest = dealerships.get(0);
         long closestDistance = 300000;
         String closestDistText = "None";
@@ -52,7 +55,7 @@ public class NearestDealershipApi implements NearestDealershipApiGateway {
                     closest = dealership;
                 }
             } catch (IOException | ParseException e) {
-                return new NearestDealershipResponseModel("none", "none", "none", "none");
+                return new NearestDealershipResponseModel("none", "none", "none", "oops");
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }

--- a/src/main/java/interface_adapters/nearest_dealership/NearestDealershipResponseFormatter.java
+++ b/src/main/java/interface_adapters/nearest_dealership/NearestDealershipResponseFormatter.java
@@ -15,6 +15,10 @@ public class NearestDealershipResponseFormatter implements NearestDealershipPres
      */
     @Override
     public void displayNearestDealership(NearestDealershipResponseModel response) {
+        if (response.getDistance().equals("none")) {
+            sendFailureMessage("Looks like there is no API key! Cannot make call to the service :(");
+            return;
+        }
         String res = String.format("The nearest dealership is %s located at %s. " +
                 "It is %s away from you and should only take you %s to get there!", response.getName(),
                 response.getLocation(), response.getDistance(), response.getDuration());

--- a/src/main/java/screens/DeletedPopUp.java
+++ b/src/main/java/screens/DeletedPopUp.java
@@ -8,7 +8,7 @@ public class DeletedPopUp extends JDialog implements ActionListener {
     private final JButton contButton;
 
     public DeletedPopUp(String message) {
-        setBounds(100, 100, 200, 100);
+        setBounds(100, 100, 300, 100);
         JLabel label = new JLabel(message);
         contButton = new JButton("Continue to Home");
         contButton.addActionListener(this);


### PR DESCRIPTION
When there was no API key present, and the find nearest dealership feature was tried out, the program would crash. 
Now after the fix, the program simply tells the user that there is no API, instead of crashing the application!